### PR TITLE
refactor: simplify RecipeInput flow and Firestore subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 # vercel
 .vercel
 .cursor
+.claude
 /memory-bank
 
 # typescript

--- a/components/RecipeBody.tsx
+++ b/components/RecipeBody.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { collection, query } from "firebase/firestore";
 import { useSession } from "next-auth/react";
-import { useCollection } from "react-firebase-hooks/firestore";
 import { useRecipeStore } from "../stores/recipeStore";
-import { db } from "../firebase";
+import { useUserRecipe } from "../lib/firebase/recipes";
 
 import { motion } from "framer-motion";
 
@@ -15,19 +13,16 @@ type Props = {
 function RecipeBody({ id }: Props) {
   const { data: session } = useSession();
   const { premadeIngredients, premadeInstructions } = useRecipeStore();
+  const [recipe] = useUserRecipe(session?.user?.email, id);
 
-  const [recipes] = useCollection(
-    session && query(collection(db, "users", session?.user?.email!, "recipes"))
-  );
-
-  // Find the current recipe from Firebase
-  const currentRecipe = recipes?.docs.find((recipe) => recipe.id === id);
-  const recipeIngredients = currentRecipe?.data()?.ingredients || [];
-  const recipeInstructions = currentRecipe?.data()?.instructions || [];
+  const recipeIngredients = recipe?.ingredients ?? [];
+  const recipeInstructions = recipe?.instructions ?? [];
 
   // Use premade if available, otherwise use Firebase data
-  const ingredients = premadeIngredients.length > 0 ? premadeIngredients : recipeIngredients;
-  const instructions = premadeInstructions.length > 0 ? premadeInstructions : recipeInstructions;
+  const ingredients =
+    premadeIngredients.length > 0 ? premadeIngredients : recipeIngredients;
+  const instructions =
+    premadeInstructions.length > 0 ? premadeInstructions : recipeInstructions;
 
   return (
     <div className="grid gap-8 pb-8 md:grid-cols-2">

--- a/components/RecipeInput.tsx
+++ b/components/RecipeInput.tsx
@@ -16,6 +16,7 @@ import { Activity } from "react";
 import { useCollection } from "react-firebase-hooks/firestore";
 import { useRecipeStore } from "../stores/recipeStore";
 import { db } from "../firebase";
+import { parseRecipeResponse } from "../lib/parseRecipeResponse";
 
 type Props = {
   id: string;
@@ -23,21 +24,15 @@ type Props = {
 
 function RecipeInput({ id }: Props) {
   const [prompt, setPrompt] = useState<string>("");
-  const [replyFromGpt, setReplyFromGpt] = useState<string | undefined>("");
   const [hidden, setHidden] = useState<boolean>(true);
   const [gptError, setGptError] = useState<string>("");
-  const [gptTitle, setGptTitle] = useState<string>("");
   const [loadingPrompt, setLoadingPrompt] = useState<boolean>(false);
-  const [gptIngredientsArray, setGptIngredientsArray] = useState<string[]>([]);
-  const [gptInstructionsArray, setGptInstructionsArray] = useState<string[]>(
-    []
-  );
-  const { mainTitle, setMainTitle } = useRecipeStore();
+  const { setMainTitle } = useRecipeStore();
 
   const router = useRouter();
   const { data: session } = useSession();
 
-  const [recipes, loading, error] = useCollection(
+  const [recipes] = useCollection(
     session &&
       query(
         collection(db, "users", session.user?.email!, "recipes"),
@@ -54,57 +49,7 @@ function RecipeInput({ id }: Props) {
     } else {
       setHidden(true);
     }
-  }, [recipes]);
-
-  useEffect(() => {
-    // scrape the recipe from the string prompt to get the title, ingredients, and instructions values
-    const errorMatch = replyFromGpt?.includes("Error");
-    setGptError(errorMatch ? "Error in response" : "");
-    if (!gptError) {
-      const titleMatch = replyFromGpt?.match(/Title: (.*)\n/);
-      setGptTitle(titleMatch ? titleMatch[1] : "");
-
-      const ingredientsMatch = replyFromGpt?.match(
-        /Ingredients:([\s\S]*?)Instructions/
-      );
-      let ingredients = ingredientsMatch ? ingredientsMatch[1].trim() : "";
-
-      const instructionsMatch = replyFromGpt?.match(/Instructions:[\s\S]*/);
-      let instructions = instructionsMatch
-        ? instructionsMatch[0].replace("Instructions:", "").trim()
-        : "";
-
-      if (ingredients) {
-        setGptIngredientsArray(ingredients.split("\n"));
-      }
-
-      if (instructions) {
-        setGptInstructionsArray(instructions.split("\n"));
-      }
-    }
-    setGptError("");
-  }, [replyFromGpt]);
-
-  useEffect(() => {
-    // when the title, ingredients, and instructions are scraped from the string prompt update the new recipe in firebase
-    if (gptTitle && gptIngredientsArray.length && gptInstructionsArray.length) {
-      const recipe = {
-        id: id,
-        title: gptTitle.toString(),
-        prompt: prompt.toString(),
-        ingredients: gptIngredientsArray,
-        instructions: gptInstructionsArray,
-      };
-
-      const recipeRef = doc(db, "users", session?.user?.email!, "recipes", id);
-      updateDoc(recipeRef, recipe);
-
-      setTimeout(() => {
-        setMainTitle(gptTitle);
-        setLoadingPrompt(false);
-      }, 800);
-    }
-  }, [gptTitle, gptIngredientsArray, gptInstructionsArray]);
+  }, [recipes, id]);
 
   const handlePromtType = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -132,41 +77,59 @@ function RecipeInput({ id }: Props) {
     if (prompt.includes("https://")) {
       setGptError("URL prompts are not available yet");
       setLoadingPrompt(false);
-    } else {
-      try {
-        const response = await fetch("/api/generate-recipe", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ prompt }),
-        });
+      return;
+    }
 
-        const data = await response.json();
+    try {
+      const response = await fetch("/api/generate-recipe", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ prompt }),
+      });
 
-        if (!response.ok) {
-          if (response.status === 429) {
-            setGptError(
-              `Rate limit exceeded. Contact the administrator at nikos@pountzas.gr`
-            );
-          } else {
-            setGptError(
-              data.error || "An error occurred while generating the recipe"
-            );
-          }
-          setLoadingPrompt(false);
-          return;
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (response.status === 429) {
+          setGptError(
+            `Rate limit exceeded. Contact the administrator at nikos@pountzas.gr`
+          );
+        } else {
+          setGptError(
+            data.error || "An error occurred while generating the recipe"
+          );
         }
-
-        setReplyFromGpt(data.content);
-      } catch (error) {
-        console.error("Error calling API:", error);
-        setGptError(
-          "Failed to connect to the recipe generation service. Please try again." +
-            error
-        );
         setLoadingPrompt(false);
+        return;
       }
+
+      const parsed = parseRecipeResponse(data.content ?? "");
+      if (!parsed.ok) {
+        setGptError(parsed.error);
+        setLoadingPrompt(false);
+        return;
+      }
+
+      const recipeRef = doc(db, "users", session?.user?.email!, "recipes", id);
+      await updateDoc(recipeRef, {
+        id,
+        title: parsed.recipe.title,
+        prompt,
+        ingredients: parsed.recipe.ingredients,
+        instructions: parsed.recipe.instructions,
+      });
+
+      setMainTitle(parsed.recipe.title);
+      setLoadingPrompt(false);
+    } catch (error) {
+      console.error("Error calling API:", error);
+      setGptError(
+        "Failed to connect to the recipe generation service. Please try again." +
+          error
+      );
+      setLoadingPrompt(false);
     }
   };
 

--- a/components/RecipeInput.tsx
+++ b/components/RecipeInput.tsx
@@ -1,21 +1,17 @@
 "use client";
 
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
-import {
-  collection,
-  orderBy,
-  query,
-  doc,
-  updateDoc,
-  deleteDoc,
-} from "firebase/firestore";
+import { deleteDoc, updateDoc } from "firebase/firestore";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 import { Activity } from "react";
-import { useCollection } from "react-firebase-hooks/firestore";
 import { useRecipeStore } from "../stores/recipeStore";
-import { db } from "../firebase";
+import {
+  findRecipeIdByPrompt,
+  useUserRecipe,
+  userRecipeDocRef,
+} from "../lib/firebase/recipes";
 import { parseRecipeResponse } from "../lib/parseRecipeResponse";
 
 type Props = {
@@ -24,56 +20,35 @@ type Props = {
 
 function RecipeInput({ id }: Props) {
   const [prompt, setPrompt] = useState<string>("");
-  const [hidden, setHidden] = useState<boolean>(true);
   const [gptError, setGptError] = useState<string>("");
   const [loadingPrompt, setLoadingPrompt] = useState<boolean>(false);
   const { setMainTitle } = useRecipeStore();
 
   const router = useRouter();
   const { data: session } = useSession();
+  const userEmail = session?.user?.email;
 
-  const [recipes] = useCollection(
-    session &&
-      query(
-        collection(db, "users", session.user?.email!, "recipes"),
-        orderBy("createdAt", "desc")
-      )
-  );
-
-  useEffect(() => {
-    if (!recipes) return;
-
-    const recipe = recipes.docs.find((recipe) => recipe.id === id);
-    if (recipe?.data().title === "") {
-      setHidden(false);
-    } else {
-      setHidden(true);
-    }
-  }, [recipes, id]);
+  const [recipe] = useUserRecipe(userEmail, id);
+  const hidden = recipe === undefined ? true : recipe.title !== "";
 
   const handlePromtType = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoadingPrompt(true);
     setGptError("");
 
-    if (!prompt) {
+    if (!prompt || !userEmail) {
       setLoadingPrompt(false);
       return;
     }
 
-    // when prompt already exist in firebase redirect to the id recipe page and delete the new one
-    if (recipes?.docs.find((recipe) => recipe.data().prompt === prompt)) {
-      const recipeId = recipes.docs.find(
-        (recipe) => recipe.data().prompt === prompt
-      )?.id;
-
-      router.replace(`/recipes/${recipeId}`);
-      await deleteDoc(doc(db, "users", session?.user?.email!, "recipes", id));
+    const existingRecipeId = await findRecipeIdByPrompt(userEmail, prompt);
+    if (existingRecipeId) {
+      router.replace(`/recipes/${existingRecipeId}`);
+      await deleteDoc(userRecipeDocRef(userEmail, id));
       setLoadingPrompt(false);
       return;
     }
 
-    // if prompt is a url
     if (prompt.includes("https://")) {
       setGptError("URL prompts are not available yet");
       setLoadingPrompt(false);
@@ -112,8 +87,7 @@ function RecipeInput({ id }: Props) {
         return;
       }
 
-      const recipeRef = doc(db, "users", session?.user?.email!, "recipes", id);
-      await updateDoc(recipeRef, {
+      await updateDoc(userRecipeDocRef(userEmail, id), {
         id,
         title: parsed.recipe.title,
         prompt,

--- a/components/RecipeItem.tsx
+++ b/components/RecipeItem.tsx
@@ -4,12 +4,12 @@ import {
   ListBulletIcon,
   TrashIcon
 } from "@heroicons/react/24/outline";
-import { deleteDoc, doc } from "firebase/firestore";
+import { deleteDoc } from "firebase/firestore";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { db } from "../firebase";
+import { userRecipeDocRef } from "../lib/firebase/recipes";
 import { useRecipeStore } from "../stores/recipeStore";
 
 type RecipeItemProps = {
@@ -38,7 +38,10 @@ function RecipeItem({ id, title }: RecipeItemProps) {
   }, [pathname]);
 
   const removeRecipe = async () => {
-    await deleteDoc(doc(db, "users", session?.user?.email!, "recipes", id));
+    const email = session?.user?.email;
+    if (!email) return;
+
+    await deleteDoc(userRecipeDocRef(email, id));
     router.replace("/");
   };
 

--- a/components/RecipeList.tsx
+++ b/components/RecipeList.tsx
@@ -1,20 +1,13 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useCollection } from "react-firebase-hooks/firestore";
-import { collection, orderBy, query } from "firebase/firestore";
-import { db } from "../firebase";
+import { useUserRecipes } from "../lib/firebase/recipes";
 import RecipeItem from "./RecipeItem";
 
 function RecipeList() {
   const { data: session } = useSession();
-  const [recipes, loading, error] = useCollection(
-    session &&
-      query(
-        collection(db, "users", session.user?.email!, "recipes"),
-        orderBy("createdAt", "desc")
-      )
-  );
+  const [recipes] = useUserRecipes(session?.user?.email);
+
   return (
     <>
       {recipes?.docs.map((recipe) => (

--- a/lib/firebase/recipes.ts
+++ b/lib/firebase/recipes.ts
@@ -1,0 +1,61 @@
+import {
+  collection,
+  doc,
+  getDocs,
+  orderBy,
+  query,
+  where,
+  type CollectionReference,
+  type DocumentReference,
+  type Query,
+} from "firebase/firestore";
+import { useCollection, useDocumentData } from "react-firebase-hooks/firestore";
+import { db } from "../../firebase";
+
+export type Recipe = {
+  title: string;
+  prompt: string;
+  ingredients: string[];
+  instructions: string[];
+  userId?: string;
+};
+
+export function userRecipesCollection(email: string): CollectionReference {
+  return collection(db, "users", email, "recipes");
+}
+
+export function userRecipesQuery(email: string): Query {
+  return query(userRecipesCollection(email), orderBy("createdAt", "desc"));
+}
+
+export function userRecipeDocRef(
+  email: string,
+  recipeId: string
+): DocumentReference {
+  return doc(db, "users", email, "recipes", recipeId);
+}
+
+export function useUserRecipes(email: string | null | undefined) {
+  return useCollection(email ? userRecipesQuery(email) : null);
+}
+
+export function useUserRecipe(
+  email: string | null | undefined,
+  recipeId: string
+) {
+  return useDocumentData<Recipe>(
+    email
+      ? (userRecipeDocRef(email, recipeId) as DocumentReference<Recipe>)
+      : null
+  );
+}
+
+export async function findRecipeIdByPrompt(
+  email: string,
+  prompt: string
+): Promise<string | null> {
+  const snapshot = await getDocs(
+    query(userRecipesCollection(email), where("prompt", "==", prompt))
+  );
+  return snapshot.docs[0]?.id ?? null;
+}

--- a/lib/parseRecipeResponse.test.ts
+++ b/lib/parseRecipeResponse.test.ts
@@ -1,0 +1,39 @@
+import { parseRecipeResponse } from "./parseRecipeResponse";
+
+const validResponse = `Title: Chicken Parmesan
+Ingredients:
+2 chicken breasts
+1 cup marinara
+Instructions:
+Bread the chicken
+Bake at 375F
+`;
+
+describe("parseRecipeResponse", () => {
+  it("parses title, ingredients, and instructions", () => {
+    const result = parseRecipeResponse(validResponse);
+
+    expect(result).toEqual({
+      ok: true,
+      recipe: {
+        title: "Chicken Parmesan",
+        ingredients: ["2 chicken breasts", "1 cup marinara"],
+        instructions: ["Bread the chicken", "Bake at 375F"],
+      },
+    });
+  });
+
+  it("returns an error when the response contains Error", () => {
+    expect(parseRecipeResponse("Error: something went wrong")).toEqual({
+      ok: false,
+      error: "Error in response",
+    });
+  });
+
+  it("returns an error when required sections are missing", () => {
+    expect(parseRecipeResponse("Title: Only a title\n")).toEqual({
+      ok: false,
+      error: "Could not parse recipe from response",
+    });
+  });
+});

--- a/lib/parseRecipeResponse.ts
+++ b/lib/parseRecipeResponse.ts
@@ -1,0 +1,37 @@
+export type ParsedRecipe = {
+  title: string;
+  ingredients: string[];
+  instructions: string[];
+};
+
+export type ParseRecipeResult =
+  | { ok: true; recipe: ParsedRecipe }
+  | { ok: false; error: string };
+
+export function parseRecipeResponse(raw: string): ParseRecipeResult {
+  if (raw.includes("Error")) {
+    return { ok: false, error: "Error in response" };
+  }
+
+  const titleMatch = raw.match(/Title: (.*)\n/);
+  const title = titleMatch ? titleMatch[1] : "";
+
+  const ingredientsMatch = raw.match(/Ingredients:([\s\S]*?)Instructions/);
+  const ingredientsText = ingredientsMatch ? ingredientsMatch[1].trim() : "";
+  const ingredients = ingredientsText ? ingredientsText.split("\n") : [];
+
+  const instructionsMatch = raw.match(/Instructions:[\s\S]*/);
+  const instructionsText = instructionsMatch
+    ? instructionsMatch[0].replace("Instructions:", "").trim()
+    : "";
+  const instructions = instructionsText ? instructionsText.split("\n") : [];
+
+  if (!title || ingredients.length === 0 || instructions.length === 0) {
+    return { ok: false, error: "Could not parse recipe from response" };
+  }
+
+  return {
+    ok: true,
+    recipe: { title, ingredients, instructions },
+  };
+}


### PR DESCRIPTION
## Summary
- Replace the three-effect parse/save pipeline in `RecipeInput` with a single async submit handler and a pure `parseRecipeResponse` helper (with tests).
- Introduce `lib/firebase/recipes.ts` with `useUserRecipe`, `useUserRecipes`, and `findRecipeIdByPrompt` so recipe detail components subscribe to one document instead of scanning the full collection.
- Reduce live Firestore listeners on `/recipes/[id]` from three collection subscriptions to one collection (sidebar) plus one shared document subscription.

## Test plan
- [ ] Create a new recipe, submit a food prompt, and confirm title/ingredients/instructions save and display correctly
- [ ] Submit the same prompt again and confirm redirect to the existing recipe (duplicate detection)
- [ ] Open an existing recipe from the sidebar and confirm body content loads
- [ ] Delete a recipe from the sidebar and confirm it is removed
- [ ] Run `npm test` and `npm run type-check`

Made with [Cursor](https://cursor.com)